### PR TITLE
Fix vendor history update and auto-refresh UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,15 +108,21 @@
 </main>
 <script>
 const data = { vendors: [] };
+let showingVendorId = null;
 
 async function loadVendors(){
     const res = await fetch('/api/vendors');
     data.vendors = await res.json();
     renderVendors();
+    if(showingVendorId){
+        const idx = data.vendors.findIndex(v=>v.id===showingVendorId);
+        if(idx !== -1){
+            showVendor(idx);
+            return;
+        }
+    }
     showAverage();
 }
-
-let showingVendor = null;
 const ctx = document.getElementById('priceChart').getContext('2d');
 let chart;
 
@@ -171,7 +177,7 @@ function renderChart(labels, prices, label) {
 }
 
 function showAverage() {
-    showingVendor = null;
+    showingVendorId = null;
     document.getElementById('toggle-average').style.display='none';
     const history = calcAverageHistory();
     updateMainPrice(history);
@@ -181,7 +187,7 @@ function showAverage() {
 
 function showVendor(index) {
     const vendor = data.vendors[index];
-    showingVendor = index;
+    showingVendorId = vendor.id;
     document.getElementById('toggle-average').style.display='block';
     const history = vendor.history;
     updateMainPrice(history);
@@ -205,6 +211,7 @@ function renderVendors() {
 document.getElementById('toggle-average').addEventListener('click', showAverage);
 
 loadVendors();
+setInterval(loadVendors, 60000);
 </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -37,9 +37,17 @@ app.put('/api/vendors/:id', (req,res)=>{
   const vendors = readVendors();
   const index = vendors.findIndex(v => v.id === req.params.id);
   if(index === -1) return res.status(404).end();
-  vendors[index] = { ...vendors[index], ...req.body };
+  const vendor = vendors[index];
+  if (req.body.name !== undefined) vendor.name = req.body.name;
+  if (req.body.price !== undefined) {
+    vendor.history.push(req.body.price);
+    if (vendor.history.length > 7) vendor.history.shift();
+    vendor.last = vendor.price;
+    vendor.price = req.body.price;
+  }
+  if (req.body.last !== undefined) vendor.last = req.body.last;
   writeVendors(vendors);
-  res.json(vendors[index]);
+  res.json(vendor);
 });
 
 app.delete('/api/vendors/:id', (req,res)=>{


### PR DESCRIPTION
## Summary
- update server to track price history and last price on vendor update
- keep selected vendor while refreshing the vendor list
- refresh data every minute so the index page stays up to date

## Testing
- `npm install`
- `npm start` *(in background)*
- `curl -s -X POST http://localhost:3000/api/vendors ...`
- `curl -s -X PUT http://localhost:3000/api/vendors/<id> ...`
- `kill %1`


------
https://chatgpt.com/codex/tasks/task_e_685654bbbc088333901041eaa9027340