### PR TITLE
Seed default vendor list on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 Sack Tracker is a demo web application that displays crawfish prices in a stock-style dashboard. A simple Node.js backend is included for vendor management.
 
-Run `npm install` and `npm start` to launch the server locally, then open `http://localhost:3000` in your browser. The page shows:
+Run `npm install` and `npm start` to launch the server locally, then open `http://localhost:3000` in your browser. The server automatically seeds a few example vendors the first time it runs so you can see the dashboard and admin interface in action. The page shows:
 
 - Current average crawfish price with color-coded trend
 - A 7-day price chart powered by Chart.js
 - Vendor tiles that let you switch the chart to each vendor's history
 
-Use the **Admin** button to manage vendors through a small admin interface.
+Use the **Admin** button to view and edit these sample vendors or add your own. Changes made in the admin page are reflected immediately on the dashboard.

--- a/server.js
+++ b/server.js
@@ -5,14 +5,46 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const DATA_FILE = path.join(__dirname, 'vendors.json');
 
+const DEFAULT_VENDORS = [
+  {
+    id: '1',
+    name: 'Crawfish Boss',
+    price: 3.25,
+    last: 3.40,
+    history: [3.4, 3.35, 3.3, 3.28, 3.27, 3.26, 3.25]
+  },
+  {
+    id: '2',
+    name: 'Big EZ Seafood',
+    price: 3.10,
+    last: 3.00,
+    history: [3.0, 3.05, 3.08, 3.1, 3.1, 3.1, 3.1]
+  },
+  {
+    id: '3',
+    name: 'Mudbug Masters',
+    price: 3.50,
+    last: 3.60,
+    history: [3.6, 3.55, 3.52, 3.5, 3.51, 3.52, 3.5]
+  }
+];
+
 app.use(express.json());
 app.use(express.static(__dirname));
 
 function readVendors(){
   if (fs.existsSync(DATA_FILE)) {
-    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+    try {
+      const data = fs.readFileSync(DATA_FILE, 'utf8');
+      if (data.trim() !== '') {
+        return JSON.parse(data);
+      }
+    } catch (err) {
+      console.error('Failed to parse vendors.json:', err);
+    }
   }
-  return [];
+  writeVendors(DEFAULT_VENDORS);
+  return DEFAULT_VENDORS;
 }
 
 function writeVendors(vendors){

--- a/vendors.json
+++ b/vendors.json
@@ -1,6 +1,47 @@
 [
-  {"id":"1","name":"Crawfish Boss","price":3.25,"last":3.40,"history":[3.4,3.35,3.3,3.28,3.27,3.26,3.25]},
-  {"id":"2","name":"Big EZ Seafood","price":3.10,"last":3.00,"history":[3.0,3.05,3.08,3.1,3.1,3.1,3.1]},
-  {"id":"3","name":"Mudbug Masters","price":3.50,"last":3.60,"history":[3.6,3.55,3.52,3.5,3.51,3.52,3.5]}
+  {
+    "id": "1",
+    "name": "Crawfish Boss",
+    "price": 3.25,
+    "last": 3.4,
+    "history": [
+      3.4,
+      3.35,
+      3.3,
+      3.28,
+      3.27,
+      3.26,
+      3.25
+    ]
+  },
+  {
+    "id": "2",
+    "name": "Big EZ Seafood",
+    "price": 3.1,
+    "last": 3,
+    "history": [
+      3,
+      3.05,
+      3.08,
+      3.1,
+      3.1,
+      3.1,
+      3.1
+    ]
+  },
+  {
+    "id": "3",
+    "name": "Mudbug Masters",
+    "price": 3.5,
+    "last": 3.6,
+    "history": [
+      3.6,
+      3.55,
+      3.52,
+      3.5,
+      3.51,
+      3.52,
+      3.5
+    ]
+  }
 ]
-


### PR DESCRIPTION
## Summary
- automatically create `vendors.json` with example vendors if it doesn't exist
- document the automatic seeding in `README`
- keep readable vendor data in repo

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6856a9f877d883338f375ba21010ca18