### PR TITLE
Center price and improve mobile admin

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -2,24 +2,32 @@
 <html lang="en">
 <head>
 <meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Admin - Sack Tracker</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&display=swap" rel="stylesheet">
 <style>
 body{font-family:'Roboto',sans-serif;background:#121212;color:#f0f0f0;padding:1rem;}
+.table-container{overflow-x:auto;margin-bottom:1rem;}
 input,button{padding:0.5rem;margin-right:0.5rem;border-radius:4px;border:none;}
 button{background:#b80000;color:white;cursor:pointer;}
-table{width:100%;border-collapse:collapse;margin-bottom:1rem;}
+table{width:100%;border-collapse:collapse;margin-bottom:1rem;min-width:500px;}
 th,td{border:1px solid #333;padding:0.5rem;text-align:left;}
+@media(max-width:600px){
+  input,button{width:100%;margin-right:0;margin-bottom:0.5rem;}
+  th,td{padding:0.25rem;}
+}
 </style>
 </head>
 <body>
 <h1>Vendor Management</h1>
+<div class="table-container">
 <table id="vendor-table">
 <thead><tr><th>Name</th><th>Price</th><th>Last</th><th>Actions</th></tr></thead>
 <tbody></tbody>
 </table>
+</div>
 <h2>Add Vendor</h2>
 <input id="name" placeholder="Name">
 <input id="price" placeholder="Price" type="number" step="0.01">

--- a/index.html
+++ b/index.html
@@ -37,12 +37,15 @@
         .price {
             font-size:2.5rem;
             font-weight:700;
+            text-align:center;
+            margin-top:1rem;
         }
         .price.green {color:#00c853;}
         .price.red {color:#b80000;}
         .subtext {
             font-size:0.9rem;
             margin-bottom:1rem;
+            text-align:center;
         }
         #chart-container {
             position:relative;


### PR DESCRIPTION
## Summary
- center the main price indicator and subtext
- add mobile viewport and responsive styling for admin page

## Testing
- `npm install`
- `npm start` *(fails to stay up because it's for manual run but prints startup message)*

------
https://chatgpt.com/codex/tasks/task_e_6856b286e0f88333a6186c843b4837ca