### PR TITLE
Fix vendor admin updates to refresh dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -55,6 +55,7 @@ document.getElementById('add-btn').addEventListener('click', async ()=>{
     const price=parseFloat(document.getElementById('price').value);
     const last=parseFloat(document.getElementById('last').value);
     await fetch('/api/vendors',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,price,last,history:[last,price]})});
+    localStorage.setItem('vendorsUpdated', Date.now());
     document.getElementById('name').value='';
     document.getElementById('price').value='';
     document.getElementById('last').value='';
@@ -66,6 +67,7 @@ document.querySelector('#vendor-table tbody').addEventListener('click',async e=>
     if(e.target.classList.contains('delete')){
         await fetch('/api/vendors/'+id,{method:'DELETE'});
         loadVendors();
+        localStorage.setItem('vendorsUpdated', Date.now());
     }
     if(e.target.classList.contains('save')){
         const row=e.target.closest('tr');
@@ -74,6 +76,7 @@ document.querySelector('#vendor-table tbody').addEventListener('click',async e=>
         const last=parseFloat(row.querySelector('.last').value);
         await fetch('/api/vendors/'+id,{method:'PUT',headers:{'Content-Type':'application/json'},body:JSON.stringify({name,price,last})});
         loadVendors();
+        localStorage.setItem('vendorsUpdated', Date.now());
     }
 });
 

--- a/index.html
+++ b/index.html
@@ -215,6 +215,12 @@ document.getElementById('toggle-average').addEventListener('click', showAverage)
 
 loadVendors();
 setInterval(loadVendors, 60000);
+
+window.addEventListener('storage', e => {
+    if(e.key === 'vendorsUpdated') {
+        loadVendors();
+    }
+});
 </script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "express": "^4.18.2"
   },
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   }
 }

--- a/server.js
+++ b/server.js
@@ -95,4 +95,8 @@ app.get('/admin', (req,res)=>{
   res.sendFile(path.join(__dirname, 'admin.html'));
 });
 
-app.listen(PORT, ()=>console.log(`Server running on port ${PORT}`));
+if (require.main === module) {
+  app.listen(PORT, ()=>console.log(`Server running on port ${PORT}`));
+} else {
+  module.exports = app;
+}

--- a/test/vendor.test.js
+++ b/test/vendor.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const app = require('../server');
+let server;
+
+test('GET /api/vendors returns array', async (t) => {
+  server = app.listen(0);
+  await new Promise(r => server.once('listening', r));
+  const port = server.address().port;
+  const res = await fetch(`http://localhost:${port}/api/vendors`);
+  assert.strictEqual(res.status, 200);
+  const data = await res.json();
+  assert.ok(Array.isArray(data));
+  server.close();
+});


### PR DESCRIPTION
## Summary
- notify the main dashboard via `localStorage` whenever vendors are modified
- listen for the `storage` event on the dashboard and reload vendors
- export the Express app so tests can import it
- add a basic test and `npm test` script

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856bff769888333bbd23ec36df77401