### PR TITLE
Add Netlify CMS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ Run `npm install` and `npm start` to launch the server locally, then open `http:
 - Vendor tiles that let you switch the chart to each vendor's history
 
 Use the **Admin** button to view, insert, edit, or delete vendor information. Any changes made in the admin page are reflected immediately on the dashboard. A starter vendor called "Sample Seafood" is included so you can try editing and saving changes right away.
+
+Netlify CMS is configured in the `admin/` folder. When deployed to Netlify, visit `/admin/` and log in with Netlify Identity to edit `vendors.json`.

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,26 @@
+backend:
+  name: git-gateway
+  branch: main
+media_folder: "uploads"
+public_folder: "/uploads"
+collections:
+  - name: vendors
+    label: Vendors
+    files:
+      - file: vendors.json
+        name: vendor_list
+        label: Vendors
+        format: json
+        fields:
+          - label: Vendor Entries
+            name: ""
+            widget: list
+            fields:
+              - {label: ID, name: id, widget: string}
+              - {label: Name, name: name, widget: string}
+              - {label: Price, name: price, widget: number}
+              - {label: Last, name: last, widget: number}
+              - label: History
+                name: history
+                widget: list
+                field: {label: Price, name: "", widget: number}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Content Manager</title>
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  functions = "netlify/functions"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/vendors/:splat"
+  status = 200

--- a/netlify/functions/vendors.js
+++ b/netlify/functions/vendors.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const DATA_FILE = path.join(__dirname, '..', '..', 'vendors.json');
+
+function readVendors() {
+  if (fs.existsSync(DATA_FILE)) {
+    try {
+      const data = fs.readFileSync(DATA_FILE, 'utf8');
+      if (data.trim() !== '') {
+        return JSON.parse(data);
+      }
+    } catch (err) {
+      console.error('Failed to parse vendors.json:', err);
+    }
+  }
+  return [];
+}
+
+function writeVendors(vendors) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(vendors, null, 2));
+}
+
+exports.handler = async (event) => {
+  const vendors = readVendors();
+  const method = event.httpMethod;
+
+  if (method === 'GET') {
+    return { statusCode: 200, body: JSON.stringify(vendors) };
+  }
+
+  if (method === 'POST') {
+    const vendor = JSON.parse(event.body || '{}');
+    vendor.id = Date.now().toString();
+    vendor.history = vendor.history || [];
+    vendors.push(vendor);
+    writeVendors(vendors);
+    return { statusCode: 200, body: JSON.stringify(vendor) };
+  }
+
+  const id = event.path.split('/').pop();
+  const index = vendors.findIndex((v) => v.id === id);
+  if (index === -1) return { statusCode: 404 };
+  const vendor = vendors[index];
+
+  if (method === 'PUT') {
+    const body = JSON.parse(event.body || '{}');
+    if (body.name !== undefined) vendor.name = body.name;
+    if (body.price !== undefined) {
+      vendor.history.push(body.price);
+      if (vendor.history.length > 7) vendor.history.shift();
+      vendor.last = vendor.price;
+      vendor.price = body.price;
+    }
+    if (body.last !== undefined) vendor.last = body.last;
+    writeVendors(vendors);
+    return { statusCode: 200, body: JSON.stringify(vendor) };
+  }
+
+  if (method === 'DELETE') {
+    const [deleted] = vendors.splice(index, 1);
+    writeVendors(vendors);
+    return { statusCode: 200, body: JSON.stringify(deleted) };
+  }
+
+  return { statusCode: 405 };
+};


### PR DESCRIPTION
## Summary
- add Netlify CMS admin interface under `admin/`
- wire up Netlify Functions for `/api/vendors` with redirect config
- document how to use Netlify CMS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685adc0a3ccc83339712b8185a3ae7b6